### PR TITLE
Executable was renamed?

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mkdir xpkg
 unzip -o -d xpkg xpkg.zip
 
 # Create the component package
-mono xpkg/xpkg.exe create sample-component-1.0.xam \
+mono xpkg/xamarin-component.exe create sample-component-1.0.xam \
     --name="My Awesome Component" \
     --summary="Add a huge amount of awesomeness to your Xamarin apps." \
     --publisher="Awesome Corp, Inc." \


### PR DESCRIPTION
The [xpkg.zip](https://components.xamarin.com/submit/xpkg) file contains `xamarin-component.exe`, not `xpkg.exe`.
